### PR TITLE
Feat/search unit tests

### DIFF
--- a/client/src/context/search.js
+++ b/client/src/context/search.js
@@ -1,14 +1,17 @@
-import { useState, useContext, createContext } from "react";
+// similar to auth.js, added in import React here, which is required because AuthProvider is a React component.
+import React, { useState, useContext, createContext } from "react";
 
 const SearchContext = createContext();
+
+// changed the state variable from auth/setAuth to search/setSearch to avoid confusion, contributing to readability and maintainability
 const SearchProvider = ({ children }) => {
-  const [auth, setAuth] = useState({
+  const [search, setSearch] = useState({
     keyword: "",
     results: [],
   });
 
   return (
-    <SearchContext.Provider value={[auth, setAuth]}>
+    <SearchContext.Provider value={[search, setSearch]}>
       {children}
     </SearchContext.Provider>
   );

--- a/client/src/context/search.test.js
+++ b/client/src/context/search.test.js
@@ -1,0 +1,61 @@
+import { cleanup, renderHook, act, waitFor } from "@testing-library/react";
+import { SearchProvider, useSearch } from "./search";
+
+beforeAll(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SearchContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should provide search state via SearchProvider", () => {
+    const { result } = renderHook(() => useSearch(), { wrapper: SearchProvider });
+    
+    expect(result.current[0]).toEqual({ keyword: "", results: [] });
+    expect(typeof result.current[1]).toBe("function");
+  });
+
+  it("should update search state with setSearch", async () => {
+    const { result } = renderHook(() => useSearch(), { wrapper: SearchProvider });
+    
+    act(() => {
+      result.current[1]({ keyword: "test", results: ["result1", "result2"] });
+    });
+    
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({ keyword: "test", results: ["result1", "result2"] });
+    });
+  });
+
+  it("should update search state with repeated calls to setSearch", async () => {
+    const { result } = renderHook(() => useSearch(), { wrapper: SearchProvider });
+    
+    act(() => {
+      result.current[1]({ keyword: "first", results: ["firstResult"] });
+    });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({ keyword: "first", results: ["firstResult"] });
+    });
+    
+    act(() => {
+      result.current[1]({ keyword: "second", results: ["secondResult", "anotherResult"] });
+    });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({ keyword: "second", results: ["secondResult", "anotherResult"] });
+    });
+  });
+});


### PR DESCRIPTION
feat(search): update context naming and add unit tests

- Renamed state variables from auth/setAuth to search/setSearch for improved clarity and maintainability.
- Added an explicit import of React in search.js to resolve Jest test failures with the new JSX runtime.
- Created search.test.js to cover the initial state and state update behaviors of the SearchContext.
- These changes enhance code readability and prepare the module for future refactoring.
