### PR TITLE
Feat/cart unit tests

### DIFF
--- a/client/src/context/auth.test.js
+++ b/client/src/context/auth.test.js
@@ -54,14 +54,25 @@ describe("AuthContext", () => {
     });
   });
 
-  it("should update auth state with setAuth", () => {
+  it("should remain in default state if localStorage returns null", async () => {
+    window.localStorage.getItem.mockReturnValue(null);
+    
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({ user: null, token: "" });
+    });
+  });
+
+  it("should handle invalid JSON in localStorage gracefully", async () => {
+    window.localStorage.getItem.mockReturnValue("invalid json");
+    
     const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
 
-    act(() => {
-      result.current[1]({ user: { name: "Bob" }, token: "abc456" });
+    // auth still kept as default
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({ user: null, token: "" });
     });
-
-    expect(result.current[0]).toEqual({ user: { name: "Bob" }, token: "abc456" });
   });
 
   it("should update axios Authorization header when token changes", async () => {
@@ -87,27 +98,16 @@ describe("AuthContext", () => {
     });
   });
 
-  it("should remain in default state if localStorage returns null", async () => {
-    window.localStorage.getItem.mockReturnValue(null);
-    
-    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
-    
-    await waitFor(() => {
-      expect(result.current[0]).toEqual({ user: null, token: "" });
-    });
-  });
-
-  it("should handle invalid JSON in localStorage gracefully", async () => {
-    window.localStorage.getItem.mockReturnValue("invalid json");
-    
+  it("should update auth state with setAuth", () => {
     const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
 
-    // auth still kept as default
-    await waitFor(() => {
-      expect(result.current[0]).toEqual({ user: null, token: "" });
+    act(() => {
+      result.current[1]({ user: { name: "Bob" }, token: "abc456" });
     });
-  });
 
+    expect(result.current[0]).toEqual({ user: { name: "Bob" }, token: "abc456" });
+  });
+  
   it("should update auth state with repeated calls to setAuth", async () => {
     const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
   

--- a/client/src/context/cart.js
+++ b/client/src/context/cart.js
@@ -1,12 +1,17 @@
-import { useState, useContext, createContext, useEffect } from "react";
+import React, { useState, useContext, createContext, useEffect } from "react";
 
 const CartContext = createContext();
 const CartProvider = ({ children }) => {
   const [cart, setCart] = useState([]);
 
+  // load cart data from localStorage on component mount, and handle JSON parsing errors gracefully, if any. this improves the robustness
   useEffect(() => {
-    let existingCartItem = localStorage.getItem("cart");
-    if (existingCartItem) setCart(JSON.parse(existingCartItem));
+    try {
+      const existingCartItem = localStorage.getItem("cart");
+      if (existingCartItem) setCart(JSON.parse(existingCartItem));
+    } catch (error) {
+      console.error("Failed to load cart from localStorage:", error);
+    }
   }, []);
 
   return (

--- a/client/src/context/cart.test.js
+++ b/client/src/context/cart.test.js
@@ -1,0 +1,91 @@
+import { cleanup, renderHook, act, waitFor } from "@testing-library/react";
+import { CartProvider, useCart } from "./cart";
+
+Object.defineProperty(window, "localStorage", {
+  value: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  cleanup();
+});
+
+describe("CartContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.getItem.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should provide default cart state via CartProvider", () => {
+    const { result } = renderHook(() => useCart(), { wrapper: CartProvider });
+
+    expect(result.current[0]).toEqual([]);
+    expect(typeof result.current[1]).toBe("function");
+  });
+
+  it("should retrieve cart from localStorage on mount if valid", async () => {
+    const storedCart = JSON.stringify([{ id: 1, name: "Test Product" }]);
+    window.localStorage.getItem.mockReturnValue(storedCart);
+
+    const { result } = renderHook(() => useCart(), { wrapper: CartProvider });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual([{ id: 1, name: "Test Product" }]);
+    });
+  });
+
+  it("should remain in default state if localStorage returns null", async () => {
+    window.localStorage.getItem.mockReturnValue(null);
+    const { result } = renderHook(() => useCart(), { wrapper: CartProvider });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual([]);
+    });
+  });
+  
+  it("should handle invalid JSON in localStorage gracefully", async () => {
+    window.localStorage.getItem.mockReturnValue("invalid json");
+
+    const { result } = renderHook(() => useCart(), { wrapper: CartProvider });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual([]);
+    });
+  });
+
+  it("should update cart state using setCart", async () => {
+    const { result } = renderHook(() => useCart(), { wrapper: CartProvider });
+    act(() => {
+      result.current[1]([{ id: 2, name: "Another Product" }]);
+    });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual([{ id: 2, name: "Another Product" }]);
+    });
+  });
+
+  it("should update cart state with repeated calls to setCart", async () => {
+    const { result } = renderHook(() => useCart(), { wrapper: CartProvider });
+    act(() => {
+      result.current[1]([{ id: 1, name: "Product 1" }]);
+    });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual([{ id: 1, name: "Product 1" }]);
+    });
+
+    act(() => {
+      result.current[1]([{ id: 1, name: "Product 1" }, { id: 2, name: "Product 2" }]);
+    });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual([{ id: 1, name: "Product 1" }, { id: 2, name: "Product 2" }]);
+    });
+  });
+});


### PR DESCRIPTION
feat(cart.js): add error handling for localStorage JSON parsing and comprehensive unit tests

- Wrapped localStorage.getItem in a try/catch block within useEffect to handle invalid JSON gracefully.
- Added a new cart.test.js file with tests covering:
  - Default state when localStorage returns null.
  - Correct cart initialization when valid JSON is present.
  - Graceful handling of invalid JSON in localStorage.
  - State updates via setCart, including repeated calls.

This commit improves the reliability and testability of the cart context without altering its core functionality.