### PR TITLE
fix: fix integration file patterns

### DIFF
--- a/jest.coverage.config.json
+++ b/jest.coverage.config.json
@@ -9,14 +9,14 @@
       "displayName": "default",
       "roots": ["<rootDir>"],
       "testMatch": [
-        "<rootDir>/config/*.(test|integration).js",
-        "<rootDir>/controllers/*.(test|integration).js",
-        "<rootDir>/helpers/*.(test|integration).js",
-        "<rootDir>/middlewares/*.(test|integration).js",
-        "<rootDir>/models/*.(test|integration).js",
-        "<rootDir>/routes/*.(test|integration).js",
-        "<rootDir>/integration-tests/*.(test|integration).js",
-        "<rootDir>/**/*.(test|integration).js"
+        "<rootDir>/config/*.test.js",
+        "<rootDir>/controllers/*.test.js",
+        "<rootDir>/helpers/*.test.js",
+        "<rootDir>/middlewares/*.test.js",
+        "<rootDir>/models/*.test.js",
+        "<rootDir>/routes/*.test.js",
+        "<rootDir>/integration-tests/*.test.js",
+        "<rootDir>/**/*.test.js"
       ],
       "testPathIgnorePatterns": ["/client/"]
     },
@@ -24,7 +24,7 @@
       "displayName": "client",
       "testEnvironment": "jsdom",
       "roots": ["<rootDir>/client/src"],
-      "testMatch": ["**/?(*.)+(spec|test|integration).[jt]s?(x)"],
+      "testMatch": ["**/?(*.)+(spec|test).[jt]s?(x)"],
       "moduleNameMapper": {
         "\\.(css|scss)$": "identity-obj-proxy"
       }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,11 +18,11 @@ sonar.language=js
 
 # Limit analysis to Javascript files in the specified sources
 sonar.inclusions=**/*.js
-sonar.exclusions=**/node_modules/**, **/*.spec.js, **/*.test.js, **/*.spec.js, **/*.integration.js, **/reportWebVitals.js
+sonar.exclusions=**/node_modules/**, **/*.spec.js, **/*.test.js, **/*.spec.js, **/reportWebVitals.js
 
 # Test files
 sonar.tests=.
-sonar.test.inclusions=**/*.test.js, **/*.spec.js, **/*.integration.js
+sonar.test.inclusions=**/*.test.js, **/*.spec.js
 
 # Debug
 sonar.verbose=true


### PR DESCRIPTION
Integration files to use .integration.test.js naming convention instead