### PR TITLE
fix: revert auth header assign back to original

### DIFF
--- a/client/src/context/auth.js
+++ b/client/src/context/auth.js
@@ -10,15 +10,8 @@ const AuthProvider = ({ children }) => {
         token: "",
     });
 
-    // Problem: If auth.token is empty, axios might send an invalid Authorization header.
-    // axios.defaults.headers.common["Authorization"] = auth?.token;
-    useEffect(() => {
-        if (auth?.token) {
-            axios.defaults.headers.common["Authorization"] = auth.token;
-        } else {
-            delete axios.defaults.headers.common["Authorization"];
-        }
-    }, [auth]);
+    //default axios
+    axios.defaults.headers.common["Authorization"] = auth?.token;
 
     // remove the "eslint-disable-next-line" by using functional updates to avoid stale closures.
     useEffect(() => {

--- a/client/src/context/auth.test.js
+++ b/client/src/context/auth.test.js
@@ -86,17 +86,17 @@ describe("AuthContext", () => {
     });
   });
 
-  it("should not set Authorization header when token is empty", async () => {
-    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+  // it("should not set Authorization header when token is empty", async () => {
+  //   const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
     
-    act(() => {
-      result.current[1]({ user: null, token: "" });
-    });
+  //   act(() => {
+  //     result.current[1]({ user: null, token: "" });
+  //   });
     
-    await waitFor(() => {
-      expect(axios.defaults.headers.common.hasOwnProperty("Authorization")).toBe(false);
-    });
-  });
+  //   await waitFor(() => {
+  //     expect(axios.defaults.headers.common.hasOwnProperty("Authorization")).toBe(false);
+  //   });
+  // });
 
   it("should update auth state with setAuth", () => {
     const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });


### PR DESCRIPTION
- somehow the 'improved' version will cause error when direct access using URL, causing problem to PlayWright UI test
- reverted back to the original version
- deleted the corresponding test case