### PR TITLE
feat(admin-route & ui-tests): gracefully handle admin auth errors and add visitor access test

### DIFF
--- a/client/src/components/Routes/AdminRoute.js
+++ b/client/src/components/Routes/AdminRoute.js
@@ -10,10 +10,15 @@ export default function AdminRoute(){
 
     useEffect(()=> {
         const authCheck = async() => {
-            const res = await axios.get("/api/v1/auth/admin-auth");
-            if(res.data.ok){
-                setOk(true);
-            } else {
+            try {
+                const res = await axios.get("/api/v1/auth/admin-auth");
+                if(res.data.ok){
+                    setOk(true);
+                } else {
+                    setOk(false);
+                }
+            } catch (error) {
+                // gracefully handle error => set ok to false
                 setOk(false);
             }
         };

--- a/ui-tests/user-admin-access-control.spec.cjs
+++ b/ui-tests/user-admin-access-control.spec.cjs
@@ -2,16 +2,42 @@ import { test, expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
 // These accounts are preset in the DB
-const adminEmail = 'cs4218admin@test.com';
-const adminPassword = 'cs4218admin@test.com';
 const userEmail = 'cs4218@test.com';
 const userPassword = 'cs4218@test.com';
+const adminEmail = 'cs4218admin@test.com';
+const adminPassword = 'cs4218admin@test.com';
 
 test.describe('Access Control Tests', () => {
   test.beforeEach(async ({ page }) => {
     // Reset the database before each test
     execSync('npm run db:reset', { stdio: 'inherit' });
     await page.goto('http://localhost:3000');
+  });
+
+  // Visitor Access Test
+  test('as a visitor, I cannot access protected pages', async ({ page }) => {
+    // Without logging in, attempt to visit a protected route
+    await page.goto('http://localhost:3000/dashboard');
+
+    // a redirect is expected
+    await expect(page.getByRole('heading')).toContainText('Redirecting');
+    await expect(page).toHaveURL('http://localhost:3000/');
+  });
+
+  // User Access Tests
+  test('as a user, I cannot access admin-protected pages', async ({ page }) => {
+    // Navigate to login page
+    await page.getByRole('link', { name: 'Login' }).click();
+    // Log in using regular user credentials
+    await page.fill('input[placeholder="Enter Your Email"]', userEmail);
+    await page.fill('input[placeholder="Enter Your Password"]', userPassword);
+    await page.getByRole('button', { name: 'LOGIN' }).click();
+
+    // Attempt to navigate to an admin-protected route
+    await page.goto('http://localhost:3000/dashboard/admin');
+    // a redirect is expected
+    await expect(page.getByRole('heading')).toContainText('Redirecting');
+    await expect(page).toHaveURL('http://localhost:3000/login');
   });
 
   // Admin Access Tests
@@ -32,18 +58,4 @@ test.describe('Access Control Tests', () => {
     await expect(page.getByRole('main')).toContainText('Admin Panel');
   });
 
-  // User Access Tests
-  test('as a user, I should not access admin-protected pages', async ({ page }) => {
-    // Navigate to login page
-    await page.getByRole('link', { name: 'Login' }).click();
-    // Log in using regular user credentials
-    await page.fill('input[placeholder="Enter Your Email"]', userEmail);
-    await page.fill('input[placeholder="Enter Your Password"]', userPassword);
-    await page.getByRole('button', { name: 'LOGIN' }).click();
-
-    // Attempt to navigate to an admin-protected route
-    await page.goto('http://localhost:3000/dashboard/admin');
-    // Verify that access is denied. (opposite of what a admin should see)
-    await expect(page.getByRole('main')).not.toContainText('Admin Panel');
-  });
 });


### PR DESCRIPTION
- Updated AdminRoute to wrap axios.get in a try/catch block, setting ok to false when an error occurs.
- Added a new visitor test case to verify that unauthenticated users cannot access protected pages.